### PR TITLE
Add zld linker

### DIFF
--- a/.cargo/config.fast
+++ b/.cargo/config.fast
@@ -5,8 +5,10 @@
 linker = "/usr/bin/clang"
 rustflags = ["-Clink-arg=-fuse-ld=lld", "-Zshare-generics=y"]
 
+# NOTE: you must manually install https://github.com/michaeleisel/zld on mac. you can easily do this with the "brew" package manager:
+# `brew install michaeleisel/zld/zld`
 [target.x86_64-apple-darwin]
-rustflags = ["-Zshare-generics=y"]
+rustflags = ["-C", "link-arg=-fuse-ld=/usr/local/Cellar/zld/1.1.0/bin/zld", "-Zshare-generics=y"]
 
 [target.x86_64-pc-windows-msvc]
 linker = "rust-lld.exe"

--- a/.cargo/config.fast
+++ b/.cargo/config.fast
@@ -8,7 +8,7 @@ rustflags = ["-Clink-arg=-fuse-ld=lld", "-Zshare-generics=y"]
 # NOTE: you must manually install https://github.com/michaeleisel/zld on mac. you can easily do this with the "brew" package manager:
 # `brew install michaeleisel/zld/zld`
 [target.x86_64-apple-darwin]
-rustflags = ["-C", "link-arg=-fuse-ld=/usr/local/Cellar/zld/1.1.0/bin/zld", "-Zshare-generics=y"]
+rustflags = ["-C", "link-arg=-fuse-ld=/usr/local/bin/zld", "-Zshare-generics=y"]
 
 [target.x86_64-pc-windows-msvc]
 linker = "rust-lld.exe"

--- a/setup
+++ b/setup
@@ -21,6 +21,10 @@ function die() {
   echo "🛑 FATAL: $1"
 }
 
+function warn() {
+  echo "⚠️ $1"
+}
+
 # --- Set package.name in Cargo.toml ---
 name_with_ext=$(git remote show -n origin | grep "Fetch URL" | cut -d / -f 2-)
 name="${name_with_ext%.*}"
@@ -29,7 +33,7 @@ if grep -q "bevy_template" Cargo.toml; then
     sed -e "s/bevy_template/${name}/" -i "" Cargo.toml || die "Couldn't set the package name to ${name}"
     result "Set package name to ${name}"
   else
-    result "Okay, you should go set the package name in Cargo.toml manually."
+    warn "Okay, you should go set the package name in Cargo.toml manually."
   fi
 else
   info "Package name already set."
@@ -43,7 +47,7 @@ if grep -q "Unknown Author" Cargo.toml; then
       die "Couldn't set the author."
     result "Set author to ${DEFAULT_AUTHOR}"
   else
-    result "Okay, you should go set the author in Cargo.toml manually."
+    warn "Okay, you should go set the author in Cargo.toml manually."
   fi
 else
   info "Author already set."
@@ -57,7 +61,7 @@ if ! grep -qE "^bevy = \"${version}\"\$" Cargo.toml; then
     sed -E -e "s/^bevy = \".*\"\$/bevy = \"${version}\"/" -i "" Cargo.toml || die "Couldn't update Bevy version to ${version}"
     result "Updated to version ${version}"
   else
-    result "Okay, leaving the version alone."
+    warn "Okay, leaving the version alone."
   fi
 else
   info "Bevy is already on the latest version (${version}), skipping version update."
@@ -67,18 +71,28 @@ fi
 if [[ -f .cargo/config.fast ]]; then
   if ask_yn "Fast-compile is not configured. Would you like me to set it up now? This involves installing an external linker and using the nightly Rust compiler."; then
     mv .cargo/config.fast .cargo/config || die "Failed moving config file into place"
-    if [[ $(uname) == "Darwin" ]]; then
-      brew install michaeleisel/zld/zld \
-        || die "Failed running 'brew install michaeleisel/zld/zld -- do you have brew installed? https://brew.sh/"
-      result "Configured fast-compile to use zld linker for debug builds."
-    else
-      echo "⚠️ PLEASE INSTALL LLD!  Instructions are available at https://bevyengine.org/learn/book/getting-started/setup/"
-    fi
+    result "Configured fast-compile to use zld/lld linker for debug builds."
   else
-    result "Okay, not configuring fast-compile."
+    warn "Okay, not configuring fast-compile."
   fi
 elif [[ -f .cargo/config ]] && grep -q -- "-Zshare-generics=y" .cargo/config; then
   info "Fast-compile is already configured. If you want to disable it, delete or comment out .cargo/config"
+fi
+
+if [[ $(uname) == "Darwin" ]]; then
+  if brew list michaeleisel/zld/zld > /dev/null 2> /dev/null ; then
+    info "zld is installed"
+  else
+    if ask_yn "Install zld? Answer yes if you configured fast-install." ; then
+      brew install michaeleisel/zld/zld \
+        || die "Failed running 'brew install michaeleisel/zld/zld -- do you have brew installed? https://brew.sh/"
+      result "installed zld"
+    else
+      warn "Okay, not installing zld."
+    fi
+  fi
+else
+  warn "PLEASE MAKE SURE YOU HAVE LLD INSTALLED!  Instructions are available at https://bevyengine.org/learn/book/getting-started/setup/"
 fi
 
 # --- Install nightly compiler ---
@@ -89,7 +103,7 @@ else
     rustup install nightly || die "Failed to install nightly compiler. Do you have rustup installed?"
     result "Done installing nightly compiler."
   else
-    result "Okay, not installing nightly compiler."
+    warn "Okay, not installing nightly compiler."
   fi
 fi
 
@@ -102,7 +116,7 @@ if rustup toolchain list | grep -q nightly; then
       rustup override set nightly || die "Failed configuring project to use nightly compiler"
       result "Configured project to use the nightly compiler."
     else
-      result "Okay, not configuring project to use the nightly compiler."
+      warn "Okay, not configuring project to use the nightly compiler."
     fi
   fi
 else
@@ -115,7 +129,7 @@ if [[ -f README.md ]] && grep -q "Bevy Template" README.md; then
     echo "# My Project" > README.md || die "Failed replacing README.md"
     result "Replaced README.md with blank one."
   else
-    result "Okay, left template README.md in place."
+    warn "Okay, left template README.md in place."
   fi
 else
   info "README.md has already been replaced"
@@ -127,7 +141,7 @@ if [[ -f LICENSE ]] && grep -q "Nathan Stocks" LICENSE; then
     rm LICENSE || die "Failed deleting LICENSE file."
     result "Deleted the LICENSE file that belonged to the template. Feel free to license your project in whatever way you choose."
   else
-    result "Left LICENSE alone."
+    warn "Okay, left LICENSE alone."
   fi
 else
   info "Template license has already been removed."

--- a/setup
+++ b/setup
@@ -2,7 +2,7 @@
 
 function ask_yn() {
   read -rp "❓ $1 (Y/n) " answer
-  if [[ "$answer" == "" || "$answer" == "y" || "$answer" == "Y" || "$answer" == "yes" || "$answer" == "Yes" ]] ; then
+  if [[ "$answer" == "" || "$answer" == "y" || "$answer" == "Y" || "$answer" == "yes" || "$answer" == "Yes" ]]; then
     return 0
   else
     return 1
@@ -17,13 +17,17 @@ function info() {
   echo "💡 $1"
 }
 
+function die() {
+  echo "🛑 FATAL: $1"
+}
+
 # --- Set package.name in Cargo.toml ---
 name_with_ext=$(git remote show -n origin | grep "Fetch URL" | cut -d / -f 2-)
 name="${name_with_ext%.*}"
-if grep -q "bevy_template" Cargo.toml ; then
-  if ask_yn "Set the package name to ${name}?" ; then
-    sed -e "s/bevy_template/${name}/" -i "" Cargo.toml \
-      && result "Set package name to ${name}"
+if grep -q "bevy_template" Cargo.toml; then
+  if ask_yn "Set the package name to ${name}?"; then
+    sed -e "s/bevy_template/${name}/" -i "" Cargo.toml || die "Couldn't set the package name to ${name}"
+    result "Set package name to ${name}"
   else
     result "Okay, you should go set the package name in Cargo.toml manually."
   fi
@@ -32,11 +36,12 @@ else
 fi
 
 # --- Set package.authors in Cargo.toml ---
-if grep -q "Unknown Author" Cargo.toml ; then
+if grep -q "Unknown Author" Cargo.toml; then
   DEFAULT_AUTHOR="$(git config --global user.name) <$(git config --global user.email)>"
-  if ask_yn "Set the author to ${DEFAULT_AUTHOR}?" ; then
-    sed -E -e "s/Unknown Author <unknown@example.com>/${DEFAULT_AUTHOR}/" -i "" Cargo.toml \
-      && result "Set author to ${DEFAULT_AUTHOR}"
+  if ask_yn "Set the author to ${DEFAULT_AUTHOR}?"; then
+    sed -E -e "s/Unknown Author <unknown@example.com>/${DEFAULT_AUTHOR}/" -i "" Cargo.toml ||
+      die "Couldn't set the author."
+    result "Set author to ${DEFAULT_AUTHOR}"
   else
     result "Okay, you should go set the author in Cargo.toml manually."
   fi
@@ -47,10 +52,10 @@ fi
 # --- Set latest version of Bevy ---
 json=$(curl --silent --user-agent "bevy_template (github.com/cleancut/bevy_template)" https://crates.io/api/v1/crates/bevy)
 version=$(echo "${json}" | grep -oE '"max_version":".*?"' | cut -d '"' -f 4)
-if ! grep -qE "^bevy = \"${version}\"\$" Cargo.toml ; then
-  if ask_yn "Try to update to the latest version of Bevy ($version)? If you have customized the version string, say no here." ; then
-    sed -E -e "s/^bevy = \".*\"\$/bevy = \"${version}\"/" -i "" Cargo.toml
-    result "Updated to version $version"
+if ! grep -qE "^bevy = \"${version}\"\$" Cargo.toml; then
+  if ask_yn "Try to update to the latest version of Bevy ($version)? If you have customized the version string, say no here."; then
+    sed -E -e "s/^bevy = \".*\"\$/bevy = \"${version}\"/" -i "" Cargo.toml || die "Couldn't update Bevy version to ${version}"
+    result "Updated to version ${version}"
   else
     result "Okay, leaving the version alone."
   fi
@@ -59,26 +64,29 @@ else
 fi
 
 # --- Configure fast-compile ---
-if [[ -f .cargo/config.fast ]] ; then
-  if ask_yn "Fast-compile is not configured. Would you like me to set it up now? If you don't want to use the nightly compiler, answer 'no'." ; then
-    mv .cargo/config.fast .cargo/config
-    result "Configured fast-compile."
-    if [[ $(uname) != "Darwin" ]] ; then
+if [[ -f .cargo/config.fast ]]; then
+  if ask_yn "Fast-compile is not configured. Would you like me to set it up now? This involves installing an external linker and using the nightly Rust compiler."; then
+    mv .cargo/config.fast .cargo/config || die "Failed moving config file into place"
+    if [[ $(uname) == "Darwin" ]]; then
+      brew install michaeleisel/zld/zld \
+        || die "Failed running 'brew install michaeleisel/zld/zld -- do you have brew installed? https://brew.sh/"
+      result "Configured fast-compile to use zld linker for debug builds."
+    else
       echo "⚠️ PLEASE INSTALL LLD!  Instructions are available at https://bevyengine.org/learn/book/getting-started/setup/"
     fi
   else
     result "Okay, not configuring fast-compile."
   fi
-elif [[ -f .cargo/config ]] && grep -q -- "-Zshare-generics=y" .cargo/config ; then
+elif [[ -f .cargo/config ]] && grep -q -- "-Zshare-generics=y" .cargo/config; then
   info "Fast-compile is already configured. If you want to disable it, delete or comment out .cargo/config"
 fi
 
 # --- Install nightly compiler ---
-if rustup toolchain list | grep -q nightly ; then
+if rustup toolchain list | grep -q nightly; then
   info "Nightly compiler already installed."
 else
-  if ask_yn "No nightly compiler installed. Install it via rustup? Answer 'yes' if you configured fast-compile." ; then
-    rustup install nightly
+  if ask_yn "No nightly compiler installed. Install it via rustup? Answer 'yes' if you configured fast-compile."; then
+    rustup install nightly || die "Failed to install nightly compiler. Do you have rustup installed?"
     result "Done installing nightly compiler."
   else
     result "Okay, not installing nightly compiler."
@@ -86,12 +94,12 @@ else
 fi
 
 # --- Configure project to use nightly compiler ---
-if rustup toolchain list | grep -q nightly ; then
-  if rustup override list | grep -qE "$(pwd).*nightly" ; then
+if rustup toolchain list | grep -q nightly; then
+  if rustup override list | grep -qE "$(pwd).*nightly"; then
     info "Already using nightly compiler for this project."
   else
-    if ask_yn "Configure this project to use the nightly compiler? Answer 'yes' if you configured fast-compile." ; then
-      rustup override set nightly
+    if ask_yn "Configure this project to use the nightly compiler? Answer 'yes' if you configured fast-compile."; then
+      rustup override set nightly || die "Failed configuring project to use nightly compiler"
       result "Configured project to use the nightly compiler."
     else
       result "Okay, not configuring project to use the nightly compiler."
@@ -102,9 +110,9 @@ else
 fi
 
 # --- Replace README.md ---
-if [[ -f README.md ]] && grep -q "Bevy Template" README.md ; then
-  if ask_yn "Replace template README.md with a blank one?" ; then
-    echo "# My Project" > README.md
+if [[ -f README.md ]] && grep -q "Bevy Template" README.md; then
+  if ask_yn "Replace template README.md with a blank one?"; then
+    echo "# My Project" > README.md || die "Failed replacing README.md"
     result "Replaced README.md with blank one."
   else
     result "Okay, left template README.md in place."
@@ -114,9 +122,9 @@ else
 fi
 
 # --- Delete the license ---
-if [[ -f LICENSE ]] && grep -q "Nathan Stocks" LICENSE ; then
-  if ask_yn "Delete the LICENSE file so you can add your own?" ; then
-    rm LICENSE
+if [[ -f LICENSE ]] && grep -q "Nathan Stocks" LICENSE; then
+  if ask_yn "Delete the LICENSE file so you can add your own?"; then
+    rm LICENSE || die "Failed deleting LICENSE file."
     result "Deleted the LICENSE file that belonged to the template. Feel free to license your project in whatever way you choose."
   else
     result "Left LICENSE alone."


### PR DESCRIPTION
- Add new zld linker for mac.
- Add fatal messages to setup script.

I must be doing something wrong.  Even though zld appears to both be installed correctly and the config file appears to be formatted correctly, I see _absolutely no difference in compile times_ on my mac.  What am I missing?  To test, I'm using this repositories' code with the `.add_default_plugins()` line commented out so that the app immediately exits after running each system once.

/cc @ashneverdawn @cart @lachlansneff from https://github.com/bevyengine/bevy/pull/312