### PR TITLE
Upstream flag change + Apple Silicon support

### DIFF
--- a/.cargo/config_fast_builds
+++ b/.cargo/config_fast_builds
@@ -10,12 +10,10 @@ rustflags = ["-Clink-arg=-fuse-ld=lld", "-Zshare-generics=y"]
 # NOTE: you must manually install https://github.com/michaeleisel/zld on mac. you can easily do this with the "brew" package manager:
 # `brew install michaeleisel/zld/zld`
 [target.x86_64-apple-darwin]
-rustflags = ["-Clink-arg=-fuse-ld=/usr/local/bin/zld", "-Csplit-debuginfo=off", "-Zshare-generics=y"]
+rustflags = ["-Clink-arg=-fuse-ld=/usr/local/bin/zld", "-Csplit-debuginfo=unpacked", "-Zshare-generics=y"]
 
-# NOTE: you must manually install https://github.com/michaeleisel/zld on mac. you can easily do this with the "brew" package manager:
-# `brew install michaeleisel/zld/zld`
 [target.aarch64-apple-darwin]
-rustflags = ["-Clink-arg=-fuse-ld=/usr/local/bin/zld", "-Csplit-debuginfo=off", "-Zshare-generics=y"]
+rustflags = ["-Clink-arg=-fuse-ld=/usr/local/bin/zld", "-Csplit-debuginfo=unpacked", "-Zshare-generics=y"]
 
 [target.x86_64-pc-windows-msvc]
 linker = "rust-lld.exe"

--- a/.cargo/config_fast_builds
+++ b/.cargo/config_fast_builds
@@ -10,7 +10,12 @@ rustflags = ["-Clink-arg=-fuse-ld=lld", "-Zshare-generics=y"]
 # NOTE: you must manually install https://github.com/michaeleisel/zld on mac. you can easily do this with the "brew" package manager:
 # `brew install michaeleisel/zld/zld`
 [target.x86_64-apple-darwin]
-rustflags = ["-C", "link-arg=-fuse-ld=/usr/local/bin/zld", "-Zshare-generics=y", "-Zrun-dsymutil=no"]
+rustflags = ["-Clink-arg=-fuse-ld=/usr/local/bin/zld", "-Csplit-debuginfo=off", "-Zshare-generics=y"]
+
+# NOTE: you must manually install https://github.com/michaeleisel/zld on mac. you can easily do this with the "brew" package manager:
+# `brew install michaeleisel/zld/zld`
+[target.aarch64-apple-darwin]
+rustflags = ["-Clink-arg=-fuse-ld=/usr/local/bin/zld", "-Csplit-debuginfo=off", "-Zshare-generics=y"]
 
 [target.x86_64-pc-windows-msvc]
 linker = "rust-lld.exe"


### PR DESCRIPTION
When https://github.com/rust-lang/rust/pull/795702 hits versions of Rust we use, this change will be needed.  Until then, I'll let this PR sit.

And I added a line for the Apple Silicon platform as well, though I don't have access to any Apple Silicon hardware, yet, so I'm shooting in the dark.